### PR TITLE
Fix topic tools display

### DIFF
--- a/common/common.scss
+++ b/common/common.scss
@@ -6270,11 +6270,6 @@ nav.post-controls .show-replies i {
 #topic-progress-wrapper .topic-admin-menu-button-container .widget-button {
   border-right: 0;
 }
-#topic-progress-wrapper .topic-admin-popup-menu.left-side, #topic-progress-wrapper .topic-admin-popup-menu.right-side {
-  position: absolute;
-  right: 0;
-  bottom: 0;
-}
 
 .topic-status-info {
   border-top: 0;

--- a/common/common.scss
+++ b/common/common.scss
@@ -6257,11 +6257,11 @@ nav.post-controls .show-replies i {
   background-color: $secondary;
   top: auto;
   right: auto;
+  left: -60px;
+  width: initial;
 }
 #topic-progress-wrapper .topic-admin-menu-button-container .toggle-admin-menu.widget-button {
   border-right: 0;
-  border-top-right-radius: 0;
-  border-bottom-right-radius: 0;
   height: auto;
 }
 #topic-progress-wrapper .topic-admin-menu-button-container .toggle-admin-menu.widget-button .fa {

--- a/scss/common/_topic-post.scss
+++ b/scss/common/_topic-post.scss
@@ -899,6 +899,7 @@ nav {
 }
 
 #topic-progress {
+  border-top-right-radius: $btn-border-radius;
   flex-shrink: 0;
   height: $btn-height;
 
@@ -908,6 +909,7 @@ nav {
 }
 
 #topic-progress-wrapper {
+  border-top-right-radius: $btn-border-radius;
   box-shadow: $card-box-shadow;
   display: flex;
   margin-right: auto;
@@ -917,13 +919,6 @@ nav {
   &.docked {
     margin-bottom: $spacer;
     right: 0;
-
-    .topic-admin-popup-menu {
-      &.left-side,
-      &.right-side {
-        right: 0;
-      }
-    }
   }
 
   .popup-menu {
@@ -939,14 +934,15 @@ nav {
   }
 
   .topic-admin-menu-button-container {
-    background-color: unquote('$secondary');
     top: auto;
-    right: auto;
-    left: -60px;
-    width: initial;
+    left: ($btn-padding-x * -2 - $material-icon-size);
+    width: auto;
 
     .toggle-admin-menu.widget-button {
       border-right: 0;
+      border-top-right-radius: 0;
+      border-bottom-left-radius: 0;
+      border-bottom-right-radius: 0;
       height: auto;
 
       .fa {
@@ -957,6 +953,11 @@ nav {
     .widget-button {
       border-right: 0;
     }
+  }
+
+  .topic-admin-popup-menu {
+    border-bottom-left-radius: 0;
+    border-bottom-right-radius: 0;
   }
 }
 

--- a/scss/common/_topic-post.scss
+++ b/scss/common/_topic-post.scss
@@ -942,11 +942,11 @@ nav {
     background-color: unquote('$secondary');
     top: auto;
     right: auto;
+    left: -60px;
+    width: initial;
 
     .toggle-admin-menu.widget-button {
       border-right: 0;
-      border-top-right-radius: 0;
-      border-bottom-right-radius: 0;
       height: auto;
 
       .fa {
@@ -956,15 +956,6 @@ nav {
 
     .widget-button {
       border-right: 0;
-    }
-  }
-
-  .topic-admin-popup-menu {
-    &.left-side,
-    &.right-side {
-      position: absolute;
-      right: 0;
-      bottom: 0;
     }
   }
 }


### PR DESCRIPTION
This PR fixes two issues with the topic tools button:

- On desktop, the topic tools button was cut off

<img width="209" alt="screen shot 2018-11-26 at 9 40 20 am" src="https://user-images.githubusercontent.com/5931623/48985747-57addf80-f15f-11e8-8095-8e1e8d683f0b.png">

- On mobile, the topic tools menu was partially hidden

<img width="173" alt="screenshot at nov 26 09-36-56" src="https://user-images.githubusercontent.com/5931623/48985748-5e3c5700-f15f-11e8-9bf9-8a2eedb22275.png">
