### PR TITLE
restore responsive editor behaviour

### DIFF
--- a/common/common.scss
+++ b/common/common.scss
@@ -4379,8 +4379,6 @@ body .bootbox.modal .modal-footer :not(.disclaimer) a.btn-primary {
 @media (min-width: 1112px) {
   #reply-control {
     border-radius: 8px 8px 0 0;
-    margin-right: 0;
-    right: 1px;
   }
 }
 @media (min-width: 1158px) {
@@ -4430,9 +4428,6 @@ body .bootbox.modal .modal-footer :not(.disclaimer) a.btn-primary {
 }
 #reply-control.edit-title .contents input#reply-title:focus, #reply-control.edit-title .contents input#reply-title:hover {
   padding-bottom: 16px;
-}
-#reply-control.hide-preview {
-  max-width: 1110px;
 }
 #reply-control.hide-preview .toggle-preview::before {
   content: 'keyboard_arrow_left';


### PR DESCRIPTION
This restores the default Discourse editor sizing, which is responsive to whether the preview is open or not.

![2018-11-26 09 49 05](https://user-images.githubusercontent.com/5931623/48985847-ad36bc00-f160-11e8-96a9-561a3e372dd9.gif)
