### PR TITLE
fix editor toggle toolbar in mobile view

### DIFF
--- a/mobile/mobile.scss
+++ b/mobile/mobile.scss
@@ -317,6 +317,13 @@ body .boxed .contents {
   overflow: hidden;
   text-overflow: ellipsis;
 }
+#reply-control .reply-to .composer-controls button {
+  padding: initial;
+
+  &.toggle-toolbar {
+    margin-right: 10px;
+  }
+}
 #reply-control .grippie::before {
   display: none;
 }


### PR DESCRIPTION
Alignment of toggle toolbar button was off in mobile view

<img width="84" alt="screen shot 2018-11-26 at 9 58 37 am" src="https://user-images.githubusercontent.com/5931623/48985946-dc99f880-f161-11e8-9504-43dcd338feef.png">