### PR TITLE
Update _variables.scss

### DIFF
--- a/scss/_variables.scss
+++ b/scss/_variables.scss
@@ -70,7 +70,7 @@ $white-divider:   rgba(255, 255, 255, .12) !default;
 
 // Basics - Misc
 
-$border-radius:     4px !default;
+$border-radius:     2px !default;
 $border-width:      1px !default;
 $control-height:    36px !default;
 $control-height-lg: 40px !default;


### PR DESCRIPTION
Material Design Guidelines require brand design, however we have no way of finding the brand border radius. Default is 2px.